### PR TITLE
fix: redirect leaked World Cup zone links to /worldcup pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -65,6 +65,21 @@ module.exports = {
         destination: "https://nfllivehub.com/",
         permanent: true,
       },
+      // World Cup 2026 zone pages live under /worldcup, but the zone app's
+      // next-intl <Link> hrefs (e.g. "/live-scores", "/terms") leak into its
+      // inline RSC payload as root-relative paths. Google harvests them from
+      // the <script> payload and resolves them against the root domain, hitting
+      // 404s. Consolidate those ghost URLs onto the real zone pages.
+      {
+        source: "/live-scores",
+        destination: "/worldcup/live-scores",
+        permanent: true,
+      },
+      {
+        source: "/terms",
+        destination: "/worldcup/terms",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Problem

Google Search Console reported `https://cesarwilliam.com/live-scores` and `https://cesarwilliam.com/terms` as **Not found (404)**.

Root cause: the World Cup 2026 zone app (proxied under `/worldcup`) links to these pages via next-intl `<Link>`. The rendered `<a>` tags are correct (`/worldcup/live-scores`), but the **logical hrefs leak into the inline RSC/Flight payload** as root-relative paths (`/live-scores`, `/terms`). Google harvests them from the `<script>` payload and resolves them against the root domain → 404.

The zone's sitemap and canonicals are all correct, so the content is fine — these are ghost URLs Google discovered from the payload.

## Fix

Add two 308 redirects in `next.config.js` so the ghost URLs consolidate onto the real zone pages:

- `/live-scores` → `/worldcup/live-scores`
- `/terms` → `/worldcup/terms`

Redirects run before rewrites in Next.js, and neither slug collides with an existing route or the `/worldcup/:path*` rewrite, so there's no loop.

## Scope

Only the two GSC-flagged slugs are redirected. `/privacy` is intentionally **not** included — it collides with the personal site's own privacy page. If other zone slugs (`/schedule`, `/stats`, `/blog`, …) surface as 404s later, the same block can be extended.

## Verify after deploy

1. Search Console → URL Inspection → **Validate Fix** on `/live-scores` and `/terms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permanent redirects for `/live-scores` and `/terms` to their updated World Cup pages.
  * Visitors reaching the old URLs will now be sent automatically to the correct destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->